### PR TITLE
fix(theme-picker): change regex to remove spaces

### DIFF
--- a/src/components/themePicker.js
+++ b/src/components/themePicker.js
@@ -14,7 +14,7 @@ const ThemePicker = ({ theme, setTheme, unlockedThemes, small }) => {
     <div className="flex m-auto md:m-0">
       <ReactTooltip />
       {allThemes.map((item, index) => {
-        const themeVal = item.toLowerCase().replaceAll(" ", "");
+        const themeVal = item.toLowerCase().replace(/ /g, '');
         if (themes.has(item) || (unlockables.has(item) && unlocked.has(item))) {
           return (
             <div key={item} className={`theme-${themeVal}`}>


### PR DESCRIPTION
`str.replaceAll()` had a bug in chrome Version 84.0.4147.105 causing the site to crash 

Using new regex with a more performant version to remove empty spaces.

`str.replace(/ /g, '');` outputs 17.767.855 transactions per second when operating on short strings ;-)